### PR TITLE
Report warnings

### DIFF
--- a/phytest/__init__.py
+++ b/phytest/__init__.py
@@ -73,3 +73,13 @@ def _data_fixture(request):
 
 def pytest_html_report_title(report):
     report.title = "report"
+
+
+def pytest_html_results_summary(prefix, summary, postfix):
+    xfail_count = summary[-4].pop()
+    summary[-4].append(xfail_count.replace("expected failures", "warnings"))
+
+
+def pytest_html_results_table_row(report, cells):
+    if cells[0][0] == "XFailed":
+        cells[0][0] = "Warning"

--- a/phytest/bio/data.py
+++ b/phytest/bio/data.py
@@ -1,4 +1,5 @@
 import re
+
 import pandas as pd
 from pandas import DataFrame
 

--- a/phytest/bio/tree.py
+++ b/phytest/bio/tree.py
@@ -1,8 +1,7 @@
 import copy
 import re
 from datetime import datetime
-from io import StringIO, BytesIO
-from pytest_html import extras
+from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 from warnings import warn
@@ -12,6 +11,7 @@ from Bio.Align import MultipleSeqAlignment
 from Bio.Phylo.BaseTree import Clade
 from Bio.Phylo.BaseTree import Tree as BioTree
 from dateutil.parser import parse
+from pytest_html import extras
 from treetime import GTR, TreeTime
 from treetime.utils import DateConversion, datetime_from_numeric, numeric_date
 
@@ -213,7 +213,7 @@ class Tree(PhytestObject, BioTree):
             )
 
     def copy(self):
-        """ Makes a deep copy of this tree. """
+        """Makes a deep copy of this tree."""
         new_copy = copy.deepcopy(self)
         return new_copy
 
@@ -296,7 +296,7 @@ class Tree(PhytestObject, BioTree):
         self,
         filename: Union[str, Path],
         *,
-        format:Optional[str] = None,
+        format: Optional[str] = None,
         regression: Optional[TreeTime] = None,
         add_internal: bool = False,
         label: bool = True,
@@ -334,7 +334,7 @@ class Tree(PhytestObject, BioTree):
         min_root_date: Optional[float] = None,
         max_root_date: Optional[float] = None,
         valid_confidence: Optional[bool] = None,
-        extra:Optional[List] = None,
+        extra: Optional[List] = None,
         warning: bool = False,
         **kwargs,
     ):
@@ -359,13 +359,13 @@ class Tree(PhytestObject, BioTree):
         regression = regression or self.root_to_tip_regression(**kwargs)
         clock_model = DateConversion.from_regression(regression.clock_model)
         root_date = clock_model.numdate_from_dist2root(0.0)
-        
+
         if extra is not None:
             f = StringIO()
             self.plot_root_to_tip(filename=f, format="svg", regression=regression)
             svg = f.getvalue()
             extra.append(extras.html(svg))
-                
+
         if min_r_squared is not None:
             assert_or_warn(
                 clock_model.r_val**2 >= min_r_squared,

--- a/phytest/main.py
+++ b/phytest/main.py
@@ -22,7 +22,7 @@ def main(
         testfile = Path(os.path.abspath((inspect.stack()[1])[1]))
     args = [testfile]
     if not verbose:
-        args.extend(["-ra", "--tb=no", "--no-header"])
+        args.extend(["-rfesw", "--tb=no", "--no-header"])
     else:
         args.extend(["-v"])
     if sequence is not None:

--- a/phytest/utils.py
+++ b/phytest/utils.py
@@ -19,7 +19,7 @@ def assert_or_warn(statement, warning, *messages):
 
     message = "\n".join(messages)
     if warning:
-        warn(message, PhytestWarning)
+        warn(message, PhytestWarning, stacklevel=3)
         pytest.xfail(f"PhytestWarning: {message}")
     else:
         raise PhytestAssertion(message)

--- a/phytest/utils.py
+++ b/phytest/utils.py
@@ -2,6 +2,8 @@ from functools import partial
 from typing import List
 from warnings import warn
 
+import pytest
+
 
 class PhytestWarning(Warning):
     pass
@@ -18,6 +20,7 @@ def assert_or_warn(statement, warning, *messages):
     message = "\n".join(messages)
     if warning:
         warn(message, PhytestWarning)
+        pytest.xfail(f"PhytestWarning: {message}")
     else:
         raise PhytestAssertion(message)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -225,7 +225,7 @@ testing = ["covdefaults (>=1.2.0)", "coverage (>=4)", "pytest (>=4)", "pytest-co
 
 [[package]]
 name = "fonttools"
-version = "4.34.0"
+version = "4.34.2"
 description = "Tools to manipulate font files"
 category = "main"
 optional = false
@@ -1487,8 +1487,8 @@ filelock = [
     {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
 ]
 fonttools = [
-    {file = "fonttools-4.34.0-py3-none-any.whl", hash = "sha256:5fd7828b9b173acc095af41740bd42cb54e38a955df83d8e2d20286fdf5725aa"},
-    {file = "fonttools-4.34.0.zip", hash = "sha256:73d3fab85790f076d56db431bfdf9ce51b566816ff74d51e050e11ab1ffa8f8b"},
+    {file = "fonttools-4.34.2-py3-none-any.whl", hash = "sha256:c6c5a896c9760132614caa57b444ee5b4719c08f84b304bf8ce9295edfb7cbc3"},
+    {file = "fonttools-4.34.2.zip", hash = "sha256:3fb3bef8e743dad8fe96e12a47a9ce9bd367ac0a24c089256615518c88309dbd"},
 ]
 identify = [
     {file = "identify-2.5.1-py2.py3-none-any.whl", hash = "sha256:0dca2ea3e4381c435ef9c33ba100a78a9b40c0bab11189c7cf121f75815efeaa"},

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -49,7 +49,7 @@ def test_cli_basic_expression(request: pytest.FixtureRequest):
             "-d",
             "examples/data/example.csv",
             "-k",
-            "test_tree_number_of_tips"
+            "test_tree_number_of_tips",
         ],
     )
     assert "1 passed" in result.stdout
@@ -124,7 +124,10 @@ def test_cli_invalid_tree_format(request: pytest.FixtureRequest):
             "-v",
         ],
     )
-    assert "Error: Invalid value for '--tree-format': 'excel' is not a valid tree format. Must be one of newick, nexus, phyloxml, nexml." in result.stdout
+    assert (
+        "Error: Invalid value for '--tree-format': 'excel' is not a valid tree format. Must be one of newick, nexus, phyloxml, nexml."
+        in result.stdout
+    )
 
 
 def test_cli_invalid_data_format(request: pytest.FixtureRequest):
@@ -143,7 +146,10 @@ def test_cli_invalid_data_format(request: pytest.FixtureRequest):
             "-v",
         ],
     )
-    assert "Error: Invalid value for '--data-format': 'pdf' is not a valid data format. Must be one of csv, tsv, excel" in result.stdout
+    assert (
+        "Error: Invalid value for '--data-format': 'pdf' is not a valid data format. Must be one of csv, tsv, excel"
+        in result.stdout
+    )
 
 
 def test_cli_invalid_sequence_format(request: pytest.FixtureRequest):
@@ -171,7 +177,7 @@ def test_cli_invalid_data(request: pytest.FixtureRequest):
         [
             str(request.path.parent / "input/basic.py"),
             "-t",
-            "phytest/bio/tree.py", # should not be read
+            "phytest/bio/tree.py",  # should not be read
             "-d",
             "phytest/bio/data.py",
             "-v",
@@ -236,4 +242,3 @@ def test_cli_alignment(request: pytest.FixtureRequest):
         ],
     )
     assert "1 passed" in result.stdout
-

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,4 +1,5 @@
 import re
+
 import pytest
 
 from phytest import Data

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,9 @@
-from phytest import main
-import pytest
 from unittest.mock import patch
+
+import pytest
+
+from phytest import main
+
 
 def test_main_basic(request: pytest.FixtureRequest):
     result = main(
@@ -11,6 +14,7 @@ def test_main_basic(request: pytest.FixtureRequest):
     )
     assert result.value == 0
 
+
 def test_tree_not_found(request: pytest.FixtureRequest, capsys):
     result = main(
         str(request.path.parent / "input/basic.py"),
@@ -20,7 +24,7 @@ def test_tree_not_found(request: pytest.FixtureRequest, capsys):
     )
     captured = capsys.readouterr()
     assert "FileNotFoundError: Unable to locate requested t" in captured.out
-    assert result.value != 0    
+    assert result.value != 0
 
 
 def test_data_not_found(request: pytest.FixtureRequest, capsys):
@@ -32,7 +36,7 @@ def test_data_not_found(request: pytest.FixtureRequest, capsys):
     )
     captured = capsys.readouterr()
     assert "FileNotFoundError: Unable to locate requested d" in captured.out
-    assert result.value != 0        
+    assert result.value != 0
 
 
 def test_sequence_not_found(request: pytest.FixtureRequest, capsys):
@@ -44,7 +48,7 @@ def test_sequence_not_found(request: pytest.FixtureRequest, capsys):
     )
     captured = capsys.readouterr()
     assert "FileNotFoundError: Unable to locate requested s" in captured.out
-    assert result.value != 0            
+    assert result.value != 0
 
 
 def test_alignment_not_found(capsys):
@@ -54,7 +58,7 @@ def test_alignment_not_found(capsys):
     )
     captured = capsys.readouterr()
     assert "FileNotFoundError: Unable to locate requested al" in captured.out
-    assert result.value != 0                
+    assert result.value != 0
 
 
 @patch.object(pytest, 'main')

--- a/tests/test_trees.py
+++ b/tests/test_trees.py
@@ -1,7 +1,8 @@
+import warnings
 from datetime import datetime
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-import warnings
+
 import pytest
 
 from phytest import Tree
@@ -162,5 +163,3 @@ def test_assert_root_to_tip_clock_filter():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         tree.assert_root_to_tip(clock_filter=3.0)
-
-


### PR DESCRIPTION
This is an attempt to include warnings in the Phytest reports. It does the following:

- As well as emitting a PhytestWarning, `utils.assert_or_warn` will mark the test as an [xfail](https://docs.pytest.org/en/7.1.x/how-to/skipping.html#xfail-mark-test-functions-as-expected-to-fail).

- The short-summary terminal output from Phytest will not display XFailed results, but they will show in the pass/fail markers as green `x` values. e.g.: 
<img width="1795" alt="Screen Shot 2022-07-07 at 21 54 58" src="https://user-images.githubusercontent.com/782987/177767354-d4f0183d-ee56-4e90-830c-c4e3aaca51e3.png">

- The html report is modified to replace "expected failures" in the summary with "warnings". In the table, any XFailed results are renamed "Warning". e.g.:
 <img width="1427" alt="Screen Shot 2022-07-07 at 21 58 31" src="https://user-images.githubusercontent.com/782987/177767959-896efd88-b3f6-4d0e-8c2e-3bb4cf63fd98.png">

I'm leaving this a draft just now as it feels a little bit hacky and I think will need discussion and testing. However, I do think this is a good solution from the point of view that it is seamless for the end user **unless** they want to write their own xfail tests within a Phytest suite. This solution also has the added benefit of requiring no PRs to upstream projects.

Keen to hear what everyone thinks!
 